### PR TITLE
Use two colons to separate punctuation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42,21 +42,21 @@ contributors: Daniel Ehrenberg
 <emu-clause id="sec-patterns-static-semantics-early-errors">
   <h1>Static Semantics: Early Errors (<a href="https://tc39.github.io/ecma262/#sec-patterns-static-semantics-early-errors">#sec-patterns-static-semantics-early-errors</a>)</h1>
   <ins class="block">
-    <emu-grammar>Atom : `(` GroupSpecifier Disjunction[?U] `)`</emu-grammar>
+    <emu-grammar>Atom :: `(` GroupSpecifier Disjunction[?U] `)`</emu-grammar>
     <ul>
       <li>
         It is a Syntax Error if |GroupSpecifier| contains an |IdentifierName| whose StringValue is `"length"`, `"index"` or `"input"`.
       </li>
     </ul>
 
-    <emu-grammar>Pattern : Disjunction</emu-grammar>
+    <emu-grammar>Pattern :: Disjunction</emu-grammar>
     <ul>
       <li>
         It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose enclosed |IdentifierName|s have the same StringValue.
       </li>
     </ul>
 
-    <emu-grammar>AtomEscape[U] : [+U] `k` GroupName</emu-grammar>
+    <emu-grammar>AtomEscape[U] :: [+U] `k` GroupName</emu-grammar>
     <ul>
       <li>
         It is a Syntax Error if the enclosing RegExp does not contain a |GroupSpecifier| with an enclosed |IdentiferName| whose StringValue equals the StringValue of the |IdentierName| of this production's |GroupName|.


### PR DESCRIPTION
Productions of the lexical and RegExp grammars are distinguished by having two colons (`::`) as separating punctuation.

https://tc39.github.io/ecma262/#sec-lexical-and-regexp-grammars

Ref. https://github.com/tc39/proposal-regexp-named-groups/commit/80dc002a4aa53b8c350347b5646f4b541ffaca6f#commitcomment-20418805